### PR TITLE
Feature/header

### DIFF
--- a/app/components/Header/Header.js
+++ b/app/components/Header/Header.js
@@ -1,0 +1,95 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import MenuIcon from '@material-ui/icons/Menu';
+
+import IconButton from '../IconButton/IconButton';
+import Menu from '../Menu/Menu';
+import MenuItem from '../Menu/MenuItem';
+import Typography from '../Typography/Typography';
+
+const StyledIconButtonMenu = styled(IconButton)`
+  && {
+    margin-right: 20px;
+  }
+`;
+
+const StyledTypography = styled(Typography)`
+  flex-grow: 1;
+`;
+
+export class Header extends Component {
+  state = {
+    anchorEl: null
+  };
+
+  handleMenuClick = event => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleMenuClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  render() {
+    const { anchorEl } = this.state;
+    const { title, onLeftMenuIconClicked } = this.props;
+    const open = Boolean(anchorEl);
+
+    return (
+      <AppBar position="static">
+        <Toolbar>
+          <StyledIconButtonMenu
+            color="inherit"
+            aria-label="Menu"
+            onClick={onLeftMenuIconClicked}
+          >
+            <MenuIcon />
+          </StyledIconButtonMenu>
+          <StyledTypography variant="title" color="inherit">
+            {title}
+          </StyledTypography>
+
+          <IconButton
+            aria-owns={open ? 'menu-appbar' : null}
+            aria-haspopup="true"
+            onClick={this.handleMenuClick}
+            color="inherit"
+          >
+            <AccountCircleIcon />
+          </IconButton>
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'right'
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right'
+            }}
+            open={open}
+            onClose={this.handleMenuClose}
+          >
+            <MenuItem onClick={this.handleMenuClose}>Profile</MenuItem>
+            <MenuItem onClick={this.handleMenuClose}>My account</MenuItem>
+            <MenuItem onClick={this.handleMenuClose}>Logout</MenuItem>
+          </Menu>
+        </Toolbar>
+      </AppBar>
+    );
+  }
+}
+
+Header.propTypes = {
+  title: PropTypes.string.isRequired,
+  onLeftMenuIconClicked: PropTypes.func.isRequired
+};
+
+Header.defaultProps = {};
+
+export default Header;

--- a/app/components/Header/Header.stories.js
+++ b/app/components/Header/Header.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Header from './Header';
+
+const placeholderTitle = 'DocNest';
+
+storiesOf('Header', module).add('default', () => (
+  <Header
+    title={placeholderTitle}
+    onLeftMenuIconClicked={() => console.log('Left menu icon clicked!')}
+  />
+));

--- a/test/storyshots/__snapshots__/storyshots.spec.js.snap
+++ b/test/storyshots/__snapshots__/storyshots.spec.js.snap
@@ -1920,6 +1920,114 @@ exports[`Storyshots Grid/Title default 1`] = `
 </div>
 `;
 
+exports[`Storyshots Header default 1`] = `
+.c0.c0 {
+  margin-right: 20px;
+}
+
+.c1 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+<header
+  className="MuiPaper-root MuiPaper-elevation4 MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary"
+>
+  <div
+    className="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
+  >
+    <button
+      aria-label="Menu"
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit c0"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiIconButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+          />
+        </svg>
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+    <h2
+      className="MuiTypography-root MuiTypography-title MuiTypography-colorInherit c1"
+    >
+      DocNest
+    </h2>
+    <button
+      aria-haspopup="true"
+      aria-owns={null}
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      <span
+        className="MuiIconButton-label"
+      >
+        <svg
+          aria-hidden="true"
+          className="MuiSvgIcon-root"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+          />
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+        </svg>
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</header>
+`;
+
 exports[`Storyshots IconButton default 1`] = `
 <button
   className="MuiButtonBase-root MuiIconButton-root"


### PR DESCRIPTION
Closes #3 

I keep the `Header` component simple as we'll evolve it when we need a specific feature (e.g. Search). We'll eventually use implement `render props` for rendering the `MenuItems` under each `Menu` (account menu, messages, notifications, etc.